### PR TITLE
fix: change dead link for non steam launcher install guide

### DIFF
--- a/PIRASAFE.md
+++ b/PIRASAFE.md
@@ -23,7 +23,7 @@ A curated list of awesome Steam Deck software, resources and more.
 - [Install ProtonGE](https://steamdeckhq.com/tips-and-guides/the-proton-ge-steam-deck-guide/) - How to install ProtonGE.
 - [Install Chiaki](https://pimylifeup.com/steam-deck-ps5-remote-play/) - How to setup Chiaki.
 - [Use Xbox Cloud Gaming](https://support.microsoft.com/en-us/topic/xbox-cloud-gaming-in-microsoft-edge-with-steam-deck-43dd011b-0ce8-4810-8302-965be6d53296) - How to use Xbox Cloud Gaming.
-- [Install NonSteamLaunchers](https://www.steamdeckgaming.net/post/easy-launchers-install-on-steam-deck) - How to install NonSteamLaunchers.
+- [Install NonSteamLaunchers](https://steamdeckhq.com/tips-and-guides/install-3rd-party-launchers-on-steam-deck/) - How to install NonSteamLaunchers.
 - [Activate SFTP](https://www.youtube.com/watch?v=Cb1U0_KbtLQ) - How to transfer files from PC to Steam Deck with SFTP.
 
 ## Hardware

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Choose what you find more suitable for you:
 - [Install ProtonGE](https://steamdeckhq.com/tips-and-guides/the-proton-ge-steam-deck-guide/) - How to install ProtonGE.
 - [Install Chiaki](https://pimylifeup.com/steam-deck-ps5-remote-play/) - How to setup Chiaki.
 - [Use Xbox Cloud Gaming](https://support.microsoft.com/en-us/topic/xbox-cloud-gaming-in-microsoft-edge-with-steam-deck-43dd011b-0ce8-4810-8302-965be6d53296) - How to use Xbox Cloud Gaming.
-- [Install NonSteamLaunchers](https://www.steamdeckgaming.net/post/easy-launchers-install-on-steam-deck) - How to install NonSteamLaunchers.
+- [Install NonSteamLaunchers](https://steamdeckhq.com/tips-and-guides/install-3rd-party-launchers-on-steam-deck/) - How to install NonSteamLaunchers.
 - [Activate SFTP](https://www.youtube.com/watch?v=Cb1U0_KbtLQ) - How to transfer files from PC to Steam Deck with SFTP.
 - [Install ProtonDB Badges Plugin](https://steamdecklife.com/2022/10/18/protondb-badges-steam-deck-plugin/) - How to install ProtonDB Badges Plugin which gives you games compatibility rating from the ProtonDB website.
 


### PR DESCRIPTION
# Pull Request
Compile all the information written below to send a legitimate pull request to the repository!

## Label:

### This PR is labeled as:
*Choose only one and remember to select the label even on the right.*

- [ ] Feature
- [x] Bug
- [ ] Other

## Linked Issue

### This PR has the following linked issues:
- Closes #39;

## Solution

### My solution is explained as follows:
As suggested, I've changed the dead link with the one given in the issue.
